### PR TITLE
FIX: Move links from legacy hamburger menu to sidebar

### DIFF
--- a/javascripts/discourse/api-initializers/init-custom-hamburger-links.js
+++ b/javascripts/discourse/api-initializers/init-custom-hamburger-links.js
@@ -1,22 +1,17 @@
 import { apiInitializer } from "discourse/lib/api";
 
 export default apiInitializer("0.8.18", (api) => {
-  (settings.Hamburger_links || "").split("|").forEach((link) => {
-    let [rawLabel, href, loc, target] = (link || "").split(",");
-    let className = `custom-hamburger-link ${rawLabel
-      .replace(/\s+/g, "-")
-      .toLowerCase()}`;
+  (settings.Hamburger_links || "").split("|").forEach((link, index) => {
+    let [rawLabel, href] = (link || "").split(",");
 
-    loc = "f" === loc ? "footerLinks" : "generalLinks";
-    target = "blank" === target ? "_blank" : "";
-
-    api.decorateWidget(`hamburger-menu:${loc}`, () => {
-      return {
-        href,
-        rawLabel,
-        className,
-        attributes: { target },
+    api.addCommunitySectionLink((baseSectionLink) => {
+      return class CustomSectionLink extends baseSectionLink {
+        name = `custom-link-${index + 1}`;
+        href = href;
+        route = "";
+        text = rawLabel;
+        title = rawLabel;
       };
-    });
+    }, false);
   });
 });


### PR DESCRIPTION
Discourse core no longer offers the option to use the legacy hamburger menu, so we need to migrate links added by this component to the sidebar which is the replacement for the legacy hamburger menu.

That said, in the new sidebar world, there's a built-in feature in the sidebar that lets admins add custom links in the sidebar, so it probably makes sense to deprecate this component altogether.